### PR TITLE
Separate expression tree from compilation

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,0 +1,11 @@
+import type { Expr } from './expr.js'
+import type { IRNode } from './ir.js'
+
+/** Interface for compiling expression trees and IR nodes into query strings. */
+export interface Compiler {
+    /** Compile an expression node to a string. */
+    compileExpr(expr: Expr): string
+
+    /** Compile a full IR tree to a query string. */
+    compileIR(node: IRNode): string
+}

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -1,132 +1,353 @@
 import type { DataType, Schema } from './datatypes.js'
 
-/**
- * Base class for all PRQL expressions. Carries both the PRQL text representation
- * and the TypeScript-level DataType for compile-time type tracking.
- */
-export class Expr<T extends DataType = DataType> {
-    constructor(
-        protected readonly _prql: string,
-        readonly dtype: T
-    ) { }
+// ---------------------------------------------------------------------------
+// Abstract Expression Nodes
+// ---------------------------------------------------------------------------
+// These form a pure expression tree with no compilation dependencies.
+// Each node represents an operation; actual compilation to PRQL/SQL
+// is handled by separate Compiler implementations.
 
-    prql(): string { return this._prql }
-
-    // Null checking
-    isNotNull(): BoolExpr {
-        return new BoolExpr(`${this._prql} != null`)
-    }
+/** Base class for all expressions. Carries the TypeScript-level DataType. */
+export abstract class Expr<T extends DataType = DataType> {
+    abstract readonly kind: string
+    constructor(readonly dtype: T) { }
 
     // Equality
-    eq(value: string | number | boolean | Expr<DataType>): BoolExpr {
-        const v = value instanceof Expr ? value.prql() : fmtLiteral(value)
-        return new BoolExpr(`${this._prql} == ${v}`)
+    eq(value: string | number | boolean | Expr<DataType>): BooleanExpr {
+        return new Eq(this, toLiteral(value))
     }
 
-    // Numeric comparisons
-    gt(value: number | Expr<DataType>): BoolExpr {
-        const v = value instanceof Expr ? value.prql() : value
-        return new BoolExpr(`${this._prql} > ${v}`)
-    }
-
-    gte(value: number | Expr<DataType>): BoolExpr {
-        const v = value instanceof Expr ? value.prql() : value
-        return new BoolExpr(`${this._prql} >= ${v}`)
-    }
-
-    lt(value: number | Expr<DataType>): BoolExpr {
-        const v = value instanceof Expr ? value.prql() : value
-        return new BoolExpr(`${this._prql} < ${v}`)
-    }
-
-    lte(value: number | Expr<DataType>): BoolExpr {
-        const v = value instanceof Expr ? value.prql() : value
-        return new BoolExpr(`${this._prql} <= ${v}`)
-    }
-
-    div(value: number | Expr<DataType>): Expr<'float64'> {
-        const v = value instanceof Expr ? value.prql() : value
-        return new Expr(`${this._prql} / ${v}`, 'float64')
+    // Null checking
+    isNotNull(): BooleanExpr {
+        return new IsNotNull(this)
     }
 
     // Aggregations (for use inside agg())
     mean(): AggExpr<'float64'> {
-        return new AggExpr(`average ${this._prql}`, 'float64')
+        return new AggExpr(new Mean(this), 'float64')
     }
 
     sum(): AggExpr<'float64'> {
-        return new AggExpr(`sum ${this._prql}`, 'float64')
+        return new AggExpr(new Sum(this), 'float64')
     }
 
     min(): AggExpr<T> {
-        return new AggExpr(`min ${this._prql}`, this.dtype)
+        return new AggExpr(new Min(this), this.dtype)
     }
 
     max(): AggExpr<T> {
-        return new AggExpr(`max ${this._prql}`, this.dtype)
+        return new AggExpr(new Max(this), this.dtype)
     }
 
     // Sort direction (for use inside sort())
     desc(): SortExpr {
-        return new SortExpr(`-${this._prql}`)
+        return new SortExpr(this, 'desc')
     }
 
     asc(): SortExpr {
-        return new SortExpr(this._prql)
+        return new SortExpr(this, 'asc')
     }
 }
 
-/** A boolean-typed expression, used in filter(). */
-export class BoolExpr extends Expr<'boolean'> {
-    constructor(prql: string) {
-        super(prql, 'boolean')
+// ---------------------------------------------------------------------------
+// Numeric expressions (int32, int64, float32, float64)
+// ---------------------------------------------------------------------------
+
+export type NumericDataType = 'int32' | 'int64' | 'float32' | 'float64'
+
+export abstract class NumericExpr<T extends NumericDataType = NumericDataType> extends Expr<T> {
+    gt(value: number | Expr<DataType>): BooleanExpr {
+        return new Gt(this, toLiteral(value))
     }
 
-    and(other: BoolExpr): BoolExpr {
-        return new BoolExpr(`(${this._prql}) && (${other._prql})`)
+    gte(value: number | Expr<DataType>): BooleanExpr {
+        return new Gte(this, toLiteral(value))
     }
 
-    or(other: BoolExpr): BoolExpr {
-        return new BoolExpr(`(${this._prql}) || (${other._prql})`)
+    lt(value: number | Expr<DataType>): BooleanExpr {
+        return new Lt(this, toLiteral(value))
+    }
+
+    lte(value: number | Expr<DataType>): BooleanExpr {
+        return new Lte(this, toLiteral(value))
+    }
+
+    div(value: number | Expr<DataType>): NumericExpr<'float64'> {
+        return new Div(this, toLiteral(value))
     }
 }
 
-/** An aggregation expression, produced by .mean(), .sum(), etc. or count(). */
-export class AggExpr<T extends DataType> extends Expr<T> {
-    constructor(prql: string, dtype: T) {
-        super(prql, dtype)
+// ---------------------------------------------------------------------------
+// String expressions
+// ---------------------------------------------------------------------------
+
+export abstract class StringExpr extends Expr<'string'> {
+    constructor() { super('string') }
+
+    upper(): StringExpr {
+        return new Upper(this)
+    }
+
+    lower(): StringExpr {
+        return new Lower(this)
+    }
+
+    contains(pattern: string): BooleanExpr {
+        return new Contains(this, new StringLiteral(pattern))
+    }
+
+    startsWith(prefix: string): BooleanExpr {
+        return new StartsWith(this, new StringLiteral(prefix))
     }
 }
 
-/** A sort key with direction, produced by .asc() or .desc(). */
-export class SortExpr {
-    constructor(readonly _prql: string) { }
+// ---------------------------------------------------------------------------
+// Boolean expressions
+// ---------------------------------------------------------------------------
+
+export abstract class BooleanExpr extends Expr<'boolean'> {
+    constructor() { super('boolean') }
+
+    and(other: BooleanExpr): BooleanExpr {
+        return new And(this, other)
+    }
+
+    or(other: BooleanExpr): BooleanExpr {
+        return new Or(this, other)
+    }
 }
 
-/**
- * A typed column reference. N is the literal column name, T is the PRQL DataType,
- * S is the schema of the table this column belongs to.
- */
-export class Col<N extends string, T extends DataType, S extends Schema = Schema> extends Expr<T> {
+// ---------------------------------------------------------------------------
+// Concrete expression nodes
+// ---------------------------------------------------------------------------
+
+// -- Column reference (for non-string, non-numeric, non-boolean types like date/datetime/interval) --
+export class ColRef<N extends string = string, T extends DataType = DataType> extends Expr<DataType> {
+    readonly kind = 'col_ref' as const
     readonly name: N
-
+    override readonly dtype: T
     constructor(name: N, dtype: T) {
-        super(name, dtype)
+        super(dtype)
+        this.name = name
+        this.dtype = dtype
+    }
+}
+
+// -- Literals --
+export class NumberLiteral extends NumericExpr<'float64'> {
+    readonly kind = 'number_literal' as const
+    constructor(readonly value: number) { super('float64') }
+}
+
+export class StringLiteral extends StringExpr {
+    readonly kind = 'string_literal' as const
+    constructor(readonly value: string) { super() }
+}
+
+export class BooleanLiteral extends BooleanExpr {
+    readonly kind = 'boolean_literal' as const
+    constructor(readonly value: boolean) { super() }
+}
+
+export class NullLiteral extends Expr<'string'> {
+    readonly kind = 'null_literal' as const
+    constructor() { super('string') }
+}
+
+// -- Comparison nodes --
+export class Eq extends BooleanExpr {
+    readonly kind = 'eq' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super() }
+}
+
+export class Gt extends BooleanExpr {
+    readonly kind = 'gt' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super() }
+}
+
+export class Gte extends BooleanExpr {
+    readonly kind = 'gte' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super() }
+}
+
+export class Lt extends BooleanExpr {
+    readonly kind = 'lt' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super() }
+}
+
+export class Lte extends BooleanExpr {
+    readonly kind = 'lte' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super() }
+}
+
+export class IsNotNull extends BooleanExpr {
+    readonly kind = 'is_not_null' as const
+    constructor(readonly operand: Expr) { super() }
+}
+
+// -- Boolean logic --
+export class And extends BooleanExpr {
+    readonly kind = 'and' as const
+    constructor(readonly left: BooleanExpr, readonly right: BooleanExpr) { super() }
+}
+
+export class Or extends BooleanExpr {
+    readonly kind = 'or' as const
+    constructor(readonly left: BooleanExpr, readonly right: BooleanExpr) { super() }
+}
+
+// -- Arithmetic --
+export class Div extends NumericExpr<'float64'> {
+    readonly kind = 'div' as const
+    constructor(readonly left: Expr, readonly right: Expr) { super('float64') }
+}
+
+// -- String operations --
+export class Upper extends StringExpr {
+    readonly kind = 'upper' as const
+    constructor(readonly operand: StringExpr) { super() }
+}
+
+export class Lower extends StringExpr {
+    readonly kind = 'lower' as const
+    constructor(readonly operand: StringExpr) { super() }
+}
+
+export class Contains extends BooleanExpr {
+    readonly kind = 'contains' as const
+    constructor(readonly operand: StringExpr, readonly pattern: StringLiteral) { super() }
+}
+
+export class StartsWith extends BooleanExpr {
+    readonly kind = 'starts_with' as const
+    constructor(readonly operand: StringExpr, readonly prefix: StringLiteral) { super() }
+}
+
+// -- Aggregation nodes --
+export class Mean extends Expr<'float64'> {
+    readonly kind = 'mean' as const
+    constructor(readonly operand: Expr) { super('float64') }
+}
+
+export class Sum extends Expr<'float64'> {
+    readonly kind = 'sum' as const
+    constructor(readonly operand: Expr) { super('float64') }
+}
+
+export class Min<T extends DataType = DataType> extends Expr<T> {
+    readonly kind = 'min' as const
+    constructor(readonly operand: Expr<T>) { super(operand.dtype) }
+}
+
+export class Max<T extends DataType = DataType> extends Expr<T> {
+    readonly kind = 'max' as const
+    constructor(readonly operand: Expr<T>) { super(operand.dtype) }
+}
+
+export class Count extends Expr<'int64'> {
+    readonly kind = 'count' as const
+    constructor() { super('int64') }
+}
+
+// -- Raw SQL --
+export class RawSql<T extends DataType = DataType> extends Expr<T> {
+    readonly kind = 'raw_sql' as const
+    constructor(readonly rawSql: string, dtype: T) { super(dtype) }
+}
+
+// ---------------------------------------------------------------------------
+// AggExpr wrapper — marks an expression as an aggregation result
+// ---------------------------------------------------------------------------
+
+export class AggExpr<T extends DataType = DataType> extends Expr<T> {
+    readonly kind = 'agg' as const
+    constructor(readonly inner: Expr, dtype: T) { super(dtype) }
+}
+
+// ---------------------------------------------------------------------------
+// SortExpr — sort key with direction
+// ---------------------------------------------------------------------------
+
+export class SortExpr {
+    constructor(
+        readonly expr: Expr,
+        readonly direction: 'asc' | 'desc',
+    ) { }
+}
+
+// ---------------------------------------------------------------------------
+// Col — typed column that extends the right expression subclass
+// ---------------------------------------------------------------------------
+
+// We need Col to extend different base classes depending on the DataType.
+// TypeScript doesn't support conditional base classes directly, so we use
+// a factory function that returns the appropriately-typed expression.
+
+/** A typed column reference. N is the literal column name, T is the DataType. */
+export type Col<N extends string = string, T extends DataType = DataType, S extends Schema = Schema> =
+    T extends 'string' ? StringCol<N> :
+    T extends NumericDataType ? NumericCol<N, T> :
+    T extends 'boolean' ? BooleanCol<N> :
+    ColRef<N, T>
+
+export class StringCol<N extends string = string> extends StringExpr {
+    readonly kind = 'col_ref' as const
+    readonly name: N
+    constructor(name: N) {
+        super()
         this.name = name
     }
 }
 
+export class NumericCol<N extends string = string, T extends NumericDataType = NumericDataType> extends NumericExpr<T> {
+    readonly kind = 'col_ref' as const
+    readonly name: N
+    constructor(name: N, dtype: T) {
+        super(dtype)
+        this.name = name
+    }
+}
+
+export class BooleanCol<N extends string = string> extends BooleanExpr {
+    readonly kind = 'col_ref' as const
+    readonly name: N
+    constructor(name: N) {
+        super()
+        this.name = name
+    }
+}
+
+/** Create a typed column reference. */
+export function col<N extends string, T extends DataType>(name: N, dtype: T): Col<N, T> {
+    if (dtype === 'string') return new StringCol(name) as Col<N, T>
+    if (dtype === 'int32' || dtype === 'int64' || dtype === 'float32' || dtype === 'float64') {
+        return new NumericCol(name, dtype) as Col<N, T>
+    }
+    if (dtype === 'boolean') return new BooleanCol(name) as Col<N, T>
+    return new ColRef(name, dtype) as Col<N, T>
+}
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
 /** Count the number of rows in the current relation. */
 export function count(): AggExpr<'int64'> {
-    return new AggExpr('count this', 'int64')
+    return new AggExpr(new Count(), 'int64')
 }
 
 /** Embed a raw SQL expression with an explicit return type. */
 export function sql<T extends DataType>(rawSql: string, dtype: T): Expr<T> {
-    return new Expr(`s"${rawSql}"`, dtype)
+    return new RawSql(rawSql, dtype)
 }
 
-function fmtLiteral(value: string | number | boolean): string {
-    if (typeof value === 'string') return `"${value}"`
-    return String(value)
+// ---------------------------------------------------------------------------
+// Helper: convert JS value or Expr to a literal Expr
+// ---------------------------------------------------------------------------
+
+function toLiteral(value: string | number | boolean | Expr): Expr {
+    if (value instanceof Expr) return value
+    if (typeof value === 'string') return new StringLiteral(value)
+    if (typeof value === 'boolean') return new BooleanLiteral(value)
+    return new NumberLiteral(value)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,19 @@
 export { Table, table } from './table.js'
-export { Expr, BoolExpr, AggExpr, SortExpr, Col, count, sql } from './expr.js'
+export {
+    Expr, NumericExpr, StringExpr, BooleanExpr,
+    AggExpr, SortExpr,
+    ColRef, StringCol, NumericCol, BooleanCol,
+    col, count, sql,
+    // Expression nodes (for compiler authors and tree walkers)
+    NumberLiteral, StringLiteral, BooleanLiteral, NullLiteral,
+    Eq, Gt, Gte, Lt, Lte, IsNotNull,
+    And, Or, Div,
+    Upper, Lower, Contains, StartsWith,
+    Mean, Sum, Min, Max, Count, RawSql,
+} from './expr.js'
+export type { Col, NumericDataType } from './expr.js'
+export type { Compiler } from './compiler.js'
+export type { IRNode } from './ir.js'
+export { PrqlCompiler } from './prql-compiler.js'
+export { SqlCompiler } from './sql-compiler.js'
 export type { Schema, DataType, JSType, SchemaToJS } from './datatypes.js'

--- a/src/ir.ts
+++ b/src/ir.ts
@@ -1,0 +1,10 @@
+import type { BooleanExpr, Expr, SortExpr } from './expr.js'
+
+/** Internal IR nodes representing table operations. */
+export type IRNode =
+    | { kind: 'table'; name: string }
+    | { kind: 'filter'; source: IRNode; condition: BooleanExpr }
+    | { kind: 'derive'; source: IRNode; derivations: [string, Expr][] }
+    | { kind: 'group'; source: IRNode; keys: string[]; aggregations: [string, Expr][] }
+    | { kind: 'sort'; source: IRNode; keys: SortExpr[] }
+    | { kind: 'take'; source: IRNode; n: number }

--- a/src/prql-compiler.ts
+++ b/src/prql-compiler.ts
@@ -1,0 +1,88 @@
+import type { Compiler } from './compiler.js'
+import type { IRNode } from './ir.js'
+import {
+    Expr, ColRef, NumberLiteral, StringLiteral, BooleanLiteral, NullLiteral,
+    Eq, Gt, Gte, Lt, Lte, IsNotNull, And, Or,
+    Div, Upper, Lower, Contains, StartsWith,
+    Mean, Sum, Min, Max, Count, RawSql, AggExpr,
+    StringCol, NumericCol, BooleanCol,
+    type SortExpr,
+} from './expr.js'
+
+export class PrqlCompiler implements Compiler {
+    compileExpr(expr: Expr): string {
+        // Column references
+        if (expr instanceof StringCol || expr instanceof NumericCol || expr instanceof BooleanCol || expr instanceof ColRef) {
+            return (expr as { name: string }).name
+        }
+
+        // Literals
+        if (expr instanceof NumberLiteral) return String(expr.value)
+        if (expr instanceof StringLiteral) return `"${expr.value}"`
+        if (expr instanceof BooleanLiteral) return String(expr.value)
+        if (expr instanceof NullLiteral) return 'null'
+
+        // Comparisons
+        if (expr instanceof Eq) return `${this.compileExpr(expr.left)} == ${this.compileExpr(expr.right)}`
+        if (expr instanceof Gt) return `${this.compileExpr(expr.left)} > ${this.compileExpr(expr.right)}`
+        if (expr instanceof Gte) return `${this.compileExpr(expr.left)} >= ${this.compileExpr(expr.right)}`
+        if (expr instanceof Lt) return `${this.compileExpr(expr.left)} < ${this.compileExpr(expr.right)}`
+        if (expr instanceof Lte) return `${this.compileExpr(expr.left)} <= ${this.compileExpr(expr.right)}`
+        if (expr instanceof IsNotNull) return `${this.compileExpr(expr.operand)} != null`
+
+        // Boolean logic
+        if (expr instanceof And) return `(${this.compileExpr(expr.left)}) && (${this.compileExpr(expr.right)})`
+        if (expr instanceof Or) return `(${this.compileExpr(expr.left)}) || (${this.compileExpr(expr.right)})`
+
+        // Arithmetic
+        if (expr instanceof Div) return `${this.compileExpr(expr.left)} / ${this.compileExpr(expr.right)}`
+
+        // String operations
+        if (expr instanceof Upper) return `upper ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Lower) return `lower ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Contains) return `contains ${this.compileExpr(expr.operand)} ${this.compileExpr(expr.pattern)}`
+        if (expr instanceof StartsWith) return `starts_with ${this.compileExpr(expr.operand)} ${this.compileExpr(expr.prefix)}`
+
+        // Aggregations
+        if (expr instanceof AggExpr) return this.compileExpr(expr.inner)
+        if (expr instanceof Mean) return `average ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Sum) return `sum ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Min) return `min ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Max) return `max ${this.compileExpr(expr.operand)}`
+        if (expr instanceof Count) return 'count this'
+
+        // Raw SQL
+        if (expr instanceof RawSql) return `s"${expr.rawSql}"`
+
+        throw new Error(`Unknown expression kind: ${expr.kind}`)
+    }
+
+    compileSortKey(sortExpr: SortExpr): string {
+        const inner = this.compileExpr(sortExpr.expr)
+        return sortExpr.direction === 'desc' ? `-${inner}` : inner
+    }
+
+    compileIR(node: IRNode): string {
+        switch (node.kind) {
+            case 'table':
+                return `from ${node.name}`
+            case 'filter':
+                return `${this.compileIR(node.source)}\nfilter ${this.compileExpr(node.condition)}`
+            case 'derive': {
+                const dervs = node.derivations.map(([k, v]) => `  ${k} = ${this.compileExpr(v)}`).join(',\n')
+                return `${this.compileIR(node.source)}\nderive {\n${dervs}\n}`
+            }
+            case 'group': {
+                const keys = node.keys.join(', ')
+                const aggs = node.aggregations.map(([k, v]) => `    ${k} = ${this.compileExpr(v)}`).join(',\n')
+                return `${this.compileIR(node.source)}\ngroup {${keys}} (\n  aggregate {\n${aggs}\n  }\n)`
+            }
+            case 'sort': {
+                const keys = node.keys.map(k => this.compileSortKey(k)).join(', ')
+                return `${this.compileIR(node.source)}\nsort {${keys}}`
+            }
+            case 'take':
+                return `${this.compileIR(node.source)}\ntake ${node.n}`
+        }
+    }
+}

--- a/src/sql-compiler.ts
+++ b/src/sql-compiler.ts
@@ -1,0 +1,29 @@
+import { compile, CompileOptions } from 'prqlc'
+import type { Compiler } from './compiler.js'
+import type { Expr } from './expr.js'
+import type { IRNode } from './ir.js'
+import { PrqlCompiler } from './prql-compiler.js'
+
+/**
+ * Compiles expression trees and IR to SQL by first generating PRQL
+ * and then using the prqlc compiler to produce SQL.
+ */
+export class SqlCompiler implements Compiler {
+    private readonly prqlCompiler = new PrqlCompiler()
+
+    compileExpr(expr: Expr): string {
+        return this.prqlCompiler.compileExpr(expr)
+    }
+
+    compileIR(node: IRNode): string {
+        const prqlText = this.prqlCompiler.compileIR(node)
+        const opts = new CompileOptions()
+        opts.format = false
+        opts.signature_comment = false
+        const result = compile(prqlText, opts)
+        if (result === undefined) {
+            throw new Error(`PRQL compilation failed for query:\n${prqlText}`)
+        }
+        return result
+    }
+}

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,42 +1,13 @@
 import type { Schema, DataType } from './datatypes.js'
-import { Col, Expr, BoolExpr, AggExpr, SortExpr } from './expr.js'
-import { compile, CompileOptions } from 'prqlc'
-
-// ---------------------------------------------------------------------------
-// Internal IR
-// ---------------------------------------------------------------------------
-
-type IRNode =
-    | { kind: 'table'; name: string }
-    | { kind: 'filter'; source: IRNode; condition: string }
-    | { kind: 'derive'; source: IRNode; derivations: [string, string][] }
-    | { kind: 'group'; source: IRNode; keys: string[]; aggregations: [string, string][] }
-    | { kind: 'sort'; source: IRNode; keys: string[] }
-    | { kind: 'take'; source: IRNode; n: number }
-
-function toPRQL(node: IRNode): string {
-    switch (node.kind) {
-        case 'table':
-            return `from ${node.name}`
-        case 'filter':
-            return `${toPRQL(node.source)}\nfilter ${node.condition}`
-        case 'derive': {
-            const dervs = node.derivations.map(([k, v]) => `  ${k} = ${v}`).join(',\n')
-            return `${toPRQL(node.source)}\nderive {\n${dervs}\n}`
-        }
-        case 'group': {
-            const keys = node.keys.join(', ')
-            const aggs = node.aggregations.map(([k, v]) => `    ${k} = ${v}`).join(',\n')
-            return `${toPRQL(node.source)}\ngroup {${keys}} (\n  aggregate {\n${aggs}\n  }\n)`
-        }
-        case 'sort': {
-            const keys = node.keys.join(', ')
-            return `${toPRQL(node.source)}\nsort {${keys}}`
-        }
-        case 'take':
-            return `${toPRQL(node.source)}\ntake ${node.n}`
-    }
-}
+import type { IRNode } from './ir.js'
+import type { Compiler } from './compiler.js'
+import {
+    Expr, BooleanExpr, AggExpr, SortExpr,
+    col, type Col, type NumericDataType,
+    StringCol, NumericCol, BooleanCol, ColRef,
+} from './expr.js'
+import { PrqlCompiler } from './prql-compiler.js'
+import { SqlCompiler } from './sql-compiler.js'
 
 // ---------------------------------------------------------------------------
 // Row and group accessors
@@ -46,7 +17,7 @@ class RowAccessor<S extends Schema> {
     constructor(private readonly _schema: S) { }
 
     col<K extends keyof S & string>(name: K): Col<K, S[K], S> {
-        return new Col(name, this._schema[name] as S[K])
+        return col(name, this._schema[name] as S[K])
     }
 }
 
@@ -67,7 +38,14 @@ class GroupAccessor<S extends Schema> extends RowAccessor<S> {
 // Helper types for group() result schema
 // ---------------------------------------------------------------------------
 
-type ColArrayNames<KC> = KC extends Array<Col<infer N, DataType, Schema>> ? N : never
+type ColName<C> =
+    C extends StringCol<infer N> ? N :
+    C extends NumericCol<infer N, NumericDataType> ? N :
+    C extends BooleanCol<infer N> ? N :
+    C extends ColRef<infer N, DataType> ? N :
+    never
+
+type ColArrayNames<KC> = KC extends Array<infer C> ? ColName<C> : never
 
 type AggResultSchema<A extends Record<string, AggExpr<DataType>>> = {
     [K in keyof A]: A[K] extends AggExpr<infer T> ? T : never
@@ -80,16 +58,16 @@ type AggResultSchema<A extends Record<string, AggExpr<DataType>>> = {
 export class Table<S extends Schema = Schema> {
     constructor(
         readonly schema: S,
-        private readonly _ir: IRNode
+        /** @internal */ readonly _ir: IRNode
     ) { }
 
     /**
      * Filter rows using a boolean expression.
      * @example penguins.filter(r => r.col("bill_length_mm").gt(40))
      */
-    filter(cb: (r: RowAccessor<S>) => BoolExpr): Table<S> {
+    filter(cb: (r: RowAccessor<S>) => BooleanExpr): Table<S> {
         const accessor = new RowAccessor(this.schema)
-        const condition = cb(accessor).prql()
+        const condition = cb(accessor)
         return new Table(this.schema, { kind: 'filter', source: this._ir, condition })
     }
 
@@ -113,14 +91,15 @@ export class Table<S extends Schema = Schema> {
         const groupAccessor = new GroupAccessor(this.schema)
         const result = transform(groupAccessor)
 
-        const keyNames = keyCols.map(c => c.name as string)
+        const keyNames = keyCols.map(c => (c as { name: string }).name)
         const aggregations = Object.entries(result.aggregations).map(
-            ([k, v]) => [k, v.prql()] as [string, string]
+            ([k, v]) => [k, v as Expr] as [string, Expr]
         )
 
         const resultSchema: Record<string, DataType> = {}
-        for (const col of keyCols) {
-            resultSchema[col.name as string] = col.dtype
+        for (const c of keyCols) {
+            const colObj = c as { name: string; dtype: DataType }
+            resultSchema[colObj.name] = colObj.dtype
         }
         for (const [k, agg] of Object.entries(result.aggregations)) {
             resultSchema[k] = agg.dtype
@@ -143,7 +122,7 @@ export class Table<S extends Schema = Schema> {
     ): Table<S & { [K in keyof D]: D[K] extends Expr<infer T> ? T : never }> {
         const accessor = new RowAccessor(this.schema)
         const derivations = cb(accessor)
-        const pairs = Object.entries(derivations).map(([k, v]) => [k, v.prql()] as [string, string])
+        const pairs = Object.entries(derivations).map(([k, v]) => [k, v] as [string, Expr])
 
         const newSchema = { ...this.schema } as Record<string, DataType>
         for (const [k, v] of Object.entries(derivations)) {
@@ -168,8 +147,10 @@ export class Table<S extends Schema = Schema> {
         const accessor = new RowAccessor(this.schema)
         const result = cb(accessor)
         const keysList = Array.isArray(result) ? result : [result]
-        const prqlKeys = keysList.map(k => k instanceof SortExpr ? k._prql : k.prql())
-        return new Table(this.schema, { kind: 'sort', source: this._ir, keys: prqlKeys })
+        const sortKeys = keysList.map(k =>
+            k instanceof SortExpr ? k : new SortExpr(k, 'asc')
+        )
+        return new Table(this.schema, { kind: 'sort', source: this._ir, keys: sortKeys })
     }
 
     /**
@@ -180,22 +161,19 @@ export class Table<S extends Schema = Schema> {
         return new Table(this.schema, { kind: 'take', source: this._ir, n })
     }
 
+    /** Compile to a query string using the given compiler. */
+    compile(compiler: Compiler): string {
+        return compiler.compileIR(this._ir)
+    }
+
     /** Return the PRQL query string for this table expression. */
     toPrql(): string {
-        return toPRQL(this._ir)
+        return this.compile(new PrqlCompiler())
     }
 
     /** Compile to SQL using the PRQL compiler. */
     toSql(): string {
-        const prqlText = this.toPrql()
-        const opts = new CompileOptions()
-        opts.format = false
-        opts.signature_comment = false
-        const result = compile(prqlText, opts)
-        if (result === undefined) {
-            throw new Error(`PRQL compilation failed for query:\n${prqlText}`)
-        }
-        return result
+        return this.compile(new SqlCompiler())
     }
 }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -129,4 +129,33 @@ describe('Tybis Integration Tests', () => {
             `)
         })
     })
+
+    describe('compile() with explicit compiler', () => {
+        it('accepts a PrqlCompiler', () => {
+            const compiler = new ty.PrqlCompiler()
+            const q = penguins.filter(r => r.col('bill_length_mm').gt(40))
+            expect(q.compile(compiler)).toMatchInlineSnapshot(`
+              "from penguins
+              filter bill_length_mm > 40"
+            `)
+        })
+
+        it('accepts a SqlCompiler', () => {
+            const compiler = new ty.SqlCompiler()
+            const sql = penguins.filter(r => r.col('bill_length_mm').gt(40)).compile(compiler)
+            expect(sql).toMatchInlineSnapshot(`"SELECT * FROM penguins WHERE bill_length_mm > 40"`)
+        })
+    })
+
+    describe('expression tree', () => {
+        it('expressions are abstract nodes, not strings', () => {
+            const q = penguins.filter(r => r.col('bill_length_mm').gt(40))
+            // The IR stores expression objects, not strings
+            const ir = q._ir
+            expect(ir.kind).toBe('filter')
+            if (ir.kind === 'filter') {
+                expect(ir.condition.kind).toBe('gt')
+            }
+        })
+    })
 })

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -56,4 +56,20 @@ describe('Type Safety', () => {
             ratio: 'float64'
         }>>()
     })
+
+    it('string columns should have string methods', () => {
+        const t = ty.table('t', { name: 'string' as const })
+        const accessor = { col: <K extends 'name'>(k: K) => ty.col(k, 'string') }
+        const nameCol = accessor.col('name')
+        // StringCol should have upper/lower/contains/startsWith
+        expectTypeOf(nameCol.upper()).toMatchTypeOf<ty.StringExpr>()
+        expectTypeOf(nameCol.lower()).toMatchTypeOf<ty.StringExpr>()
+        expectTypeOf(nameCol.contains('x')).toMatchTypeOf<ty.BooleanExpr>()
+    })
+
+    it('numeric columns should have comparison methods', () => {
+        const numCol = ty.col('age', 'int32')
+        expectTypeOf(numCol.gt(5)).toMatchTypeOf<ty.BooleanExpr>()
+        expectTypeOf(numCol.div(2)).toMatchTypeOf<ty.NumericExpr<'float64'>>()
+    })
 })


### PR DESCRIPTION
Restructure the codebase to decouple abstract expression representation from compilation:

- Expression tree (src/expr.ts): Pure TypeScript expression nodes (Eq, Gt, And, Or, Div, Mean, etc.) with no compilation dependencies. Split Expr into typed subclasses: StringExpr (with .upper(), .lower(), .contains(), .startsWith()), NumericExpr (with .gt(), .lt(), .div()), and BooleanExpr (with .and(), .or()). Column references are similarly typed: StringCol, NumericCol, BooleanCol.

- IR (src/ir.ts): Table operation nodes now store expression objects instead of pre-compiled strings.

- Compiler interface (src/compiler.ts): Abstract interface for compiling expression trees and IR nodes to query strings.

- PrqlCompiler (src/prql-compiler.ts): Walks the expression tree to produce PRQL text.

- SqlCompiler (src/sql-compiler.ts): Generates SQL by first producing PRQL via PrqlCompiler, then compiling with prqlc.

- Table gains a .compile(compiler) method for explicit compiler choice; .toPrql() and .toSql() remain as convenience methods.

This separation allows future optimization/rewrite passes over the expression tree without depending on any specific compilation target.

https://claude.ai/code/session_01JKijapfQARAvowViYB52va